### PR TITLE
Fix: result's index should be original list index

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -128,36 +128,25 @@ var Wade = function(data) {
 
     containsPrefix(keywords[fullWordsLength], index, results, resultsLocations, scoreIncrement);
 
-    if (results.length && search.indexMap) {
-      results.forEach(function(r) {
-        r.index = search.indexMap[r.index];
-      });
-    }
-
     return results;
   }
 
   if(Array.isArray(data)) {
-    var normalizedData = [];
     var item = null;
     var indexMap = [];
     var dataLen, normalized = 0;
+    var normalizedData = new Array(dataLen);
 
     for(var i = 0, dataLen = data.length; i < dataLen; i++) {
       item = Wade.process(data[i]);
-      if(item !== false) {
-        normalizedData.push(item);
-        indexMap[normalized++] = i;
-      }
+      normalizedData[i] = item || undefined;
     }
 
     search.index = Wade.index(normalizedData);
     search.data = normalizedData;
-    if (dataLen !== normalized) search.indexMap = indexMap;
   } else {
     search.index = data.index;
     search.data = data.data;
-    search.indexMap = data.indexMap;
   }
 
   return search;
@@ -182,6 +171,7 @@ Wade.process = function(item) {
 Wade.index = function(data) {
   var index = {};
   for(var i = 0; i < data.length; i++) {
+    if (!data[i]) continue;
     var str = getWords(data[i]);
     for(var j = 0; j < str.length; j++) {
       var item = str[j];

--- a/src/index.js
+++ b/src/index.js
@@ -128,25 +128,36 @@ var Wade = function(data) {
 
     containsPrefix(keywords[fullWordsLength], index, results, resultsLocations, scoreIncrement);
 
+    if (results.length && search.indexMap) {
+      results.forEach(function(r) {
+        r.index = search.indexMap[r.index];
+      });
+    }
+
     return results;
   }
 
   if(Array.isArray(data)) {
     var normalizedData = [];
     var item = null;
+    var indexMap = [];
+    var dataLen, normalized = 0;
 
-    for(var i = 0; i < data.length; i++) {
+    for(var i = 0, dataLen = data.length; i < dataLen; i++) {
       item = Wade.process(data[i]);
       if(item !== false) {
         normalizedData.push(item);
+        indexMap[normalized++] = i;
       }
     }
 
     search.index = Wade.index(normalizedData);
     search.data = normalizedData;
+    if (dataLen !== normalized) search.indexMap = indexMap;
   } else {
     search.index = data.index;
     search.data = data.data;
+    search.indexMap = data.indexMap;
   }
 
   return search;

--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ var Wade = function(data) {
   if(Array.isArray(data)) {
     var item = null;
     var dataLen = data.length;
-    var normalizedData = new Array();
+    var normalizedData = new Array(dataLen);
 
     for(var i = 0; i < dataLen; i++) {
       item = Wade.process(data[i]);

--- a/src/index.js
+++ b/src/index.js
@@ -133,10 +133,10 @@ var Wade = function(data) {
 
   if(Array.isArray(data)) {
     var item = null;
-    var dataLen, normalized = 0;
-    var normalizedData = new Array(dataLen);
+    var dataLen = data.length;
+    var normalizedData = new Array();
 
-    for(var i = 0, dataLen = data.length; i < dataLen; i++) {
+    for(var i = 0; i < dataLen; i++) {
       item = Wade.process(data[i]);
       normalizedData[i] = item || undefined;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,6 @@ var Wade = function(data) {
 
   if(Array.isArray(data)) {
     var item = null;
-    var indexMap = [];
     var dataLen, normalized = 0;
     var normalizedData = new Array(dataLen);
 


### PR DESCRIPTION
when i try this example: http://moonjs.ga/examples/search/index.html
i tap 'catch' but result list is not what i want

because after  pipeline, some item may be removed because of zero length, so the index in result is not the original list index

so we can record index map (if need) to fix this problem